### PR TITLE
ci: don't publish build artifacts

### DIFF
--- a/vsts-ci.yml
+++ b/vsts-ci.yml
@@ -16,15 +16,3 @@ steps:
     npm install
     npm run build
   displayName: 'npm build'
-
-- task: ArchiveFiles@1
-  inputs:
-    rootFolder: "$(System.DefaultWorkingDirectory)"
-    includeRootFolder: "false"
-  displayName: 'Archive Build Results'
-
-- task: PublishBuildArtifacts@1
-  inputs:
-    pathToPublish: "$(Build.ArtifactStagingDirectory)"
-    artifactName: "drop"
-  displayName: 'Publish Build Artifacts'


### PR DESCRIPTION
Don't publish build artifacts as part of the PR and CI builds; that's something that we'll do as part of the release pipeline.