### PR TITLE
Allow PR authors to trigger rebuilds

### DIFF
--- a/src/github-types.ts
+++ b/src/github-types.ts
@@ -1,7 +1,8 @@
 interface PullRequest {
     base: {
         ref: string
-    }
+    },
+    user: User
 }
 
 interface User {

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,6 +77,19 @@ class RebuildCommand {
     return false
   }
 
+  async ensureAuthorship(pr: PullRequest) {
+    this.log.debug('Ensuring that ' + this.user.login + ' authored pull request ' + this.issue_number)
+
+    if (this.user.login == pr.user.login) {
+      this.log.trace(this.user.login + ' is the pull request author')
+      return true
+    }
+
+    this.log.trace(this.user.login + ' is not the pull request author, permission validation failed')
+
+    return false
+  }
+
   connectToVSTS(): vsts.WebApi {
     var url = process.env.VSTS_URL
     var auth_handler = vsts.getPersonalAccessTokenHandler(process.env.VSTS_PAT as string)
@@ -245,7 +258,7 @@ class RebuildCommand {
         return
       }
 
-      if (!await this.ensureCollaboratorPermissions()) {
+      if (!(await this.ensureCollaboratorPermissions() || await this.ensureAuthorship(pull_request))) {
         this.fail(`you're not allowed to do that`)
         return
       }


### PR DESCRIPTION
This *should* allow PR authors to trigger a rebuild on their own.

Note this is a complete shot in the dark, since I don't usually Javascript, and I'm not sure I can test it locally anyway (I at least managed to `npm start`, which failed in a non-configured way).